### PR TITLE
Add RunWithEnv and TryWithEnv

### DIFF
--- a/bootstrapper/cmd/cmd.go
+++ b/bootstrapper/cmd/cmd.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"flag"
+	"fmt"
 	"log"
 	"os"
 	"os/exec"
@@ -27,25 +28,35 @@ func Try(name string, arg ...string) {
 
 // RunWithEnv works like Run, but allows the user to set the environment
 // variables, in addition to those inherited from the parent process.
-func RunWithEnv(env []string, name string, arg ...string) {
+func RunWithEnv(env map[string]string, name string, arg ...string) {
 	run(true, env, name, arg)
 }
 
 // TryWithEnv works like Try, but allows the user to set the environment
 // variables, in addition to those inherited from the parent process.
-func TryWithEnv(env []string, name string, arg ...string) {
+func TryWithEnv(env map[string]string, name string, arg ...string) {
 	run(false, env, name, arg)
 }
 
-func run(panic bool, env []string, name string, arg []string) {
+func run(panic bool, env map[string]string, name string, arg []string) {
 	log.Printf("Running %s %s ...", name, strings.Join(arg, " "))
 	cmd := exec.Command(name, arg...)
 
+	// Inherit environ from the parent process. Note that, instead
+	// of appending env to cmd.Env, we rewrite the value of an
+	// environment varaible in cmd.Env if it is in env.  This
+	// prevents from cases like two GOPATH variables in cmd.Env.
 	for _, en := range os.Environ() {
+		kv := strings.Split(en, "=")
+		if v := env[kv[0]]; v != "" {
+			en = fmt.Sprintf("%s=%s", kv[0], v)
+			delete(env, kv[0])
+		}
 		cmd.Env = append(cmd.Env, en)
 	}
-	for _, en := range env {
-		cmd.Env = append(cmd.Env, en)
+
+	for k, v := range env {
+		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", k, v))
 	}
 
 	p := log.Printf

--- a/bootstrapper/cmd/cmd.go
+++ b/bootstrapper/cmd/cmd.go
@@ -16,16 +16,37 @@ var (
 // log.Panic the stdout and stderr of the command, only if the
 // execution goes wrong.
 func Run(name string, arg ...string) {
-	run(true, name, arg)
+	run(true, nil, name, arg)
 }
 
+// Try works like Run, but doesn't panic if the commands returns a
+// non-zero value.
 func Try(name string, arg ...string) {
-	run(false, name, arg)
+	run(false, nil, name, arg)
 }
 
-func run(panic bool, name string, arg []string) {
+// RunWithEnv works like Run, but allows the user to set the environment
+// variables, in addition to those inherited from the parent process.
+func RunWithEnv(env []string, name string, arg ...string) {
+	run(true, env, name, arg)
+}
+
+// TryWithEnv works like Try, but allows the user to set the environment
+// variables, in addition to those inherited from the parent process.
+func TryWithEnv(env []string, name string, arg ...string) {
+	run(false, env, name, arg)
+}
+
+func run(panic bool, env []string, name string, arg []string) {
 	log.Printf("Running %s %s ...", name, strings.Join(arg, " "))
 	cmd := exec.Command(name, arg...)
+
+	for _, en := range os.Environ() {
+		cmd.Env = append(cmd.Env, en)
+	}
+	for _, en := range env {
+		cmd.Env = append(cmd.Env, en)
+	}
 
 	p := log.Printf
 	if panic {

--- a/bootstrapper/cmd/cmd_test.go
+++ b/bootstrapper/cmd/cmd_test.go
@@ -1,14 +1,29 @@
 package cmd
 
 import (
+	"fmt"
+	"io/ioutil"
+	"path"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
-func TestRun(t *testing.T) {
+func TestRunAndTry(t *testing.T) {
 	*Silent = true
 	assert.NotPanics(t, func() { Run("ls", "/") })
 	assert.Panics(t, func() { Run("something-not-exists") })
 	assert.NotPanics(t, func() { Try("something-not-exists") })
+}
+
+func TestRunWithEnv(t *testing.T) {
+	tmpdir, _ := ioutil.TempDir("", "")
+	tmpfile := path.Join(tmpdir, "TestRunWithEnv")
+
+	RunWithEnv([]string{"GOPATH=/tmp"},
+		"awk",
+		fmt.Sprintf("BEGIN{print ENVIRON[\"GOPATH\"] > \"%s\";}", tmpfile))
+
+	b, _ := ioutil.ReadFile(tmpfile)
+	assert.Equal(t, "/tmp\n", string(b))
 }

--- a/bootstrapper/cmd/cmd_test.go
+++ b/bootstrapper/cmd/cmd_test.go
@@ -20,10 +20,18 @@ func TestRunWithEnv(t *testing.T) {
 	tmpdir, _ := ioutil.TempDir("", "")
 	tmpfile := path.Join(tmpdir, "TestRunWithEnv")
 
-	RunWithEnv([]string{"GOPATH=/tmp"},
+	RunWithEnv(map[string]string{"GOPATH": "/tmp"},
 		"awk",
 		fmt.Sprintf("BEGIN{print ENVIRON[\"GOPATH\"] > \"%s\";}", tmpfile))
 
 	b, _ := ioutil.ReadFile(tmpfile)
 	assert.Equal(t, "/tmp\n", string(b))
+}
+
+func ExampleRunWithEnv() {
+	RunWithEnv(map[string]string{
+		"GOPATH": "/tmp",
+		"GOOS":   "linux",
+		"GOARCH": "amd64"},
+		"go", "get", "-u", "github.com/skynetservices/skydns")
 }


### PR DESCRIPTION
So we can do 

```
cmd.RunWithEnv([]string{"GOPATH=/tmp"}, "go", "get", "github.com/skynetservices/skydns")
```

to build SkyDNS and save into `/tmp/bin/skydns`.