### PR TITLE
Add cache for cloud-config-server

### DIFF
--- a/cloud-config-server/cache/cache.go
+++ b/cloud-config-server/cache/cache.go
@@ -1,0 +1,122 @@
+package cache
+
+import (
+	"io/ioutil"
+	"log"
+	"net/http"
+	"time"
+)
+
+// Cache manages a local in-memory copy of a remote file as well as a
+// local on-disk copy.  It periodically read the remote file (which
+// might change occasionally), update the local in-memory and on-disk
+// copy.
+//
+// Example:
+/*
+func main() {
+  c := cache.New(url, filename)
+  http.Handle("/", handler)
+}
+
+func handler(...) {
+  c.Get() // returns cache content and triggers update. No waiting.
+}
+*/
+type Cache struct {
+	filename string
+	url      string
+	content  []byte // Don't write into content.
+
+	update chan int // Writing into this channel tiggers an update.
+	close  chan int // Writing into this channel closes the cache.
+}
+
+const (
+	loadTimeout  = 15 * time.Second
+	updatePeriod = 20 * time.Second
+)
+
+// New panics if it fails to read remote nor local file; othersie it
+// returns a ready-to-read in-memory cache.  To close the cache and
+// free all resources, write into channel Cache.close.
+func New(url, filename string) *Cache {
+	c := &Cache{
+		filename: filename,
+		url:      url,
+		content:  load(url, filename),
+		update:   make(chan int, 1),
+		close:    make(chan int),
+	}
+
+	go func() {
+		tic := time.Tick(updatePeriod)
+		for {
+			select {
+			case <-tic:
+			case <-c.update:
+			}
+
+			if b, e := httpGet(c.url, loadTimeout); e == nil {
+				c.content = b
+				if e := ioutil.WriteFile(c.filename, b, 0644); e != nil {
+					log.Printf("Cannot write to local file %s: %v", c.filename, e)
+				}
+			}
+
+			select {
+			case <-c.close:
+				close(c.update)
+				close(c.close)
+				return
+			default:
+			}
+		}
+	}()
+
+	return c
+}
+
+// local panics if cannot read remote nor local file.
+func load(url, fn string) []byte {
+	b, e := httpGet(url, loadTimeout)
+	if e != nil {
+		log.Printf("Cannot load from %s: %v. Try load from local file.", url, e)
+		if b, e = ioutil.ReadFile(fn); e != nil {
+			log.Panicf("Cannot load from local file %s either: %v", fn, e)
+		}
+	}
+	return b
+}
+
+func httpGet(url string, timeout time.Duration) ([]byte, error) {
+	client := http.Client{
+		Timeout: timeout,
+	}
+	resp, err := client.Get(url)
+	if err != nil || resp.StatusCode != 200 {
+		log.Printf("%v", err)
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		log.Printf("%v", err)
+		return nil, err
+	}
+	return body, nil
+}
+
+func (c *Cache) Get() []byte {
+	b := c.content
+	select {
+	case c.update <- 1:
+	default:
+	}
+	return b
+}
+
+func (c *Cache) Close() {
+	c.close <- 1
+}

--- a/cloud-config-server/cache/cache.go
+++ b/cloud-config-server/cache/cache.go
@@ -1,6 +1,7 @@
 package cache
 
 import (
+	"fmt"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -95,8 +96,7 @@ func httpGet(url string, timeout time.Duration) ([]byte, error) {
 	}
 	resp, err := client.Get(url)
 	if err != nil || resp.StatusCode != 200 {
-		log.Printf("%v", err)
-		return nil, err
+		return nil, fmt.Errorf("%s, StatusCode=%d", err, resp.StatusCode)
 	}
 	defer resp.Body.Close()
 

--- a/cloud-config-server/cache/cache_test.go
+++ b/cloud-config-server/cache/cache_test.go
@@ -1,0 +1,34 @@
+package cache
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"path"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCacheWithUpdate(t *testing.T) {
+	srv := 0
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, "%05d", srv)
+		srv++
+	})
+
+	ln, e := net.Listen("tcp", ":0")
+	assert.Nil(t, e)
+	go http.Serve(ln, nil)
+
+	url := fmt.Sprintf("http://%s/", ln.Addr())
+	tmpdir, _ := ioutil.TempDir("", "")
+	cache := New(url, path.Join(tmpdir, "cachefile"))
+
+	for i := 0; i < 10; i++ {
+		assert.Equal(t, fmt.Sprintf("%05d", i), string(cache.Get()))
+		time.Sleep(50 * time.Millisecond)
+	}
+}

--- a/cloud-config-server/cache/cache_test.go
+++ b/cloud-config-server/cache/cache_test.go
@@ -9,19 +9,22 @@ import (
 	"testing"
 	"time"
 
+	"github.com/etix/stoppableListener"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestCacheWithUpdate(t *testing.T) {
+	mux := http.NewServeMux()
 	srv := 0
-	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintf(w, "%05d", srv)
 		srv++
 	})
 
 	ln, e := net.Listen("tcp", ":0")
 	assert.Nil(t, e)
-	go http.Serve(ln, nil)
+	stoppable := stoppableListener.Handle(ln)
+	go http.Serve(stoppable, mux)
 
 	url := fmt.Sprintf("http://%s/", ln.Addr())
 	tmpdir, _ := ioutil.TempDir("", "")
@@ -29,6 +32,34 @@ func TestCacheWithUpdate(t *testing.T) {
 
 	for i := 0; i < 10; i++ {
 		assert.Equal(t, fmt.Sprintf("%05d", i), string(cache.Get()))
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	stoppable.Stop <- true
+}
+
+func TestCacheWithConstantServer(t *testing.T) {
+	mux := http.NewServeMux()
+	srv := 0
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		if srv == 0 {
+			fmt.Fprintf(w, "%05d", srv)
+			srv++
+		} else {
+			http.Error(w, "no longer works", http.StatusInternalServerError)
+		}
+	})
+
+	ln, e := net.Listen("tcp", ":0")
+	assert.Nil(t, e)
+	go http.Serve(ln, mux)
+
+	url := fmt.Sprintf("http://%s/", ln.Addr())
+	tmpdir, _ := ioutil.TempDir("", "")
+	cache := New(url, path.Join(tmpdir, "cachefile"))
+
+	for i := 0; i < 10; i++ {
+		assert.Equal(t, "00000", string(cache.Get()))
 		time.Sleep(50 * time.Millisecond)
 	}
 }

--- a/cloud-config-server/cache/cache_test.go
+++ b/cloud-config-server/cache/cache_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/etix/stoppableListener"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -23,8 +22,7 @@ func TestCacheWithUpdate(t *testing.T) {
 
 	ln, e := net.Listen("tcp", ":0")
 	assert.Nil(t, e)
-	stoppable := stoppableListener.Handle(ln)
-	go http.Serve(stoppable, mux)
+	go http.Serve(ln, mux)
 
 	url := fmt.Sprintf("http://%s/", ln.Addr())
 	tmpdir, _ := ioutil.TempDir("", "")
@@ -34,8 +32,6 @@ func TestCacheWithUpdate(t *testing.T) {
 		assert.Equal(t, fmt.Sprintf("%05d", i), string(cache.Get()))
 		time.Sleep(50 * time.Millisecond)
 	}
-
-	stoppable.Stop <- true
 }
 
 func TestCacheWithConstantServer(t *testing.T) {


### PR DESCRIPTION
```
var (
  c *cache.Cache
)

func main() {
  c = cache.New(url, filename)
  http.Handle("/", handler)
}

func handler(...) {
  c.Get() // returns cache content and triggers update. No waiting.
}
```