### PR TITLE
Add unit test for cloud-config-server

### DIFF
--- a/cloud-config-server/server.go
+++ b/cloud-config-server/server.go
@@ -1,63 +1,69 @@
+// cloud-config-server starts an HTTP server, which can be accessed
+// via URLs in the form of
+//
+//   http://<addr:port>?mac=aa:bb:cc:dd:ee:ff
+//
+// and returns the cloud-config YAML file specificially tailored for
+// the node whose primary NIC's MAC address matches that specified in
+// above URL.
 package main
 
 import (
 	"flag"
 	"fmt"
+	"io/ioutil"
 	"log"
 	"net/http"
+	"path"
 	"strings"
 	"text/template"
 
 	"github.com/gorilla/mux"
 	"github.com/k8sp/auto-install/cloud-config-server/cache"
-	tp "github.com/k8sp/auto-install/cloud-config-server/template"
-	tpcfg "github.com/k8sp/auto-install/config"
+	cctemplate "github.com/k8sp/auto-install/cloud-config-server/template"
+	"github.com/k8sp/auto-install/config"
+	"github.com/topicai/candy"
 	"gopkg.in/yaml.v2"
 )
 
-var templateURL = "https://raw.githubusercontent.com/k8sp/auto-install/master/cloud-config-server/template/cloud-config.template?token=ABVwef_01-UjZGXlw2ZXgCKfZM58UEsyks5XnquFwA%3D%3D"
-var configURL = "https://raw.githubusercontent.com/k8sp/auto-install/master/cloud-config-server/template/unisound-ailab/build_config.yml?token=ABVwec2SvquxRR_h9JF-9Rg8RvuuWjcpks5XnqyawA%3D%3D"
-var configCache *cache.Cache
-var templCache *cache.Cache
-
 func main() {
-	flag.StringVar(&configURL, "configURL", "https://raw.githubusercontent.com/k8sp/auto-install/master/cloud-config-server/template/unisound-ailab/build_config.yml?token=ABVwec2SvquxRR_h9JF-9Rg8RvuuWjcpks5XnqyawA%3D%3D", "cluster config yaml file url")
-	flag.StringVar(&templateURL, "templateURL", "https://raw.githubusercontent.com/k8sp/auto-install/master/cloud-config-server/template/cloud-config.template?token=ABVwef_01-UjZGXlw2ZXgCKfZM58UEsyks5XnquFwA%3D%3D", "cloud-config template url")
+	clusterDesc := flag.String("cluster-desc",
+		"https://raw.githubusercontent.com/k8sp/auto-install/master/cloud-config-server/template/unisound-ailab/build_config.yml",
+		"URL to cluster description YAML file.")
+	ccTemplate := flag.String("cc-template",
+		"https://raw.githubusercontent.com/k8sp/auto-install/master/cloud-config-server/template/cloud-config.template",
+		"URL to cloud-config file template.")
+	addr := flag.String("addr", ":8080", "Listening address")
 	flag.Parse()
 
-	configCache = cache.New(configURL, "./cluster-desc.yml")
-	templCache = cache.New(templateURL, "./cloud-config.template")
-
-	router := mux.NewRouter().StrictSlash(true)
-	router.HandleFunc("/cloud-config/{mac}", HTTPHandler)
-	log.Printf("%v\n", http.ListenAndServe(":8080", router))
+	run(*clusterDesc, *ccTemplate, *addr)
 }
 
-// HTTPHandler process http request.
-func HTTPHandler(w http.ResponseWriter, r *http.Request) {
-	defer func() {
-		if err := recover(); err != nil {
-			http.Error(w, fmt.Sprint(err), http.StatusInternalServerError)
-		}
-	}()
+func run(clusterDesc, ccTemplate, listenAddr string) {
+	dir, e := ioutil.TempDir("", "")
+	candy.Must(e)
+	clusterCache := cache.New(clusterDesc, path.Join(dir, "cluster-desc.yml"))
+	templCache := cache.New(ccTemplate, path.Join(dir, "cloud-config.template"))
 
-	vars := mux.Vars(r)
+	router := mux.NewRouter().StrictSlash(true)
+	router.HandleFunc("/cloud-config/{mac}",
+		makeSafeHandler(func(w http.ResponseWriter, r *http.Request) {
+			mac := strings.ToLower(mux.Vars(r)["mac"])
+			tmpl := template.Must(template.New("template").Parse(string(templCache.Get())))
+			c := &config.Cluster{}
+			candy.Must(yaml.Unmarshal([]byte(string(clusterCache.Get())), c))
+			candy.Must(cctemplate.Execute(tmpl, c, mac, w))
+		}))
+	log.Printf("%v", http.ListenAndServe(listenAddr, router))
+}
 
-	mac := strings.ToLower(vars["mac"])
-	mac = strings.Replace(mac, ".yml", "", -1)
-	mac = strings.Replace(mac, ":", "-", -1)
-
-	config := string(configCache.Get())
-	templ := string(templCache.Get())
-
-	if templ == "" || config == "" {
-		w.WriteHeader(http.StatusInternalServerError)
-		w.Write([]byte("SERVER ERROR!\n"))
-		return
+func makeSafeHandler(h http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		defer func() {
+			if err := recover(); err != nil {
+				http.Error(w, fmt.Sprint(err), http.StatusInternalServerError)
+			}
+		}()
+		h(w, r)
 	}
-
-	tpl := template.Must(template.New("template").Parse(templ))
-	cfg := &tpcfg.Cluster{}
-	yaml.Unmarshal([]byte(config), &cfg)
-	tp.Execute(tpl, cfg, mac, w)
 }

--- a/cloud-config-server/server_test.go
+++ b/cloud-config-server/server_test.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"path"
+	"testing"
+
+	"gopkg.in/yaml.v2"
+
+	"github.com/k8sp/auto-install/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/topicai/candy"
+)
+
+const (
+	tmplFile = "src/github.com/k8sp/auto-install/cloud-config-server/template/cloud-config.template"
+)
+
+func TestRun(t *testing.T) {
+	// Run the cloud-config-server in a goroutine.
+	ccTmpl, e := ioutil.ReadFile(path.Join(candy.GoPath(), tmplFile))
+	candy.Must(e)
+
+	ccTemplate := func() string { return string(ccTmpl) }
+	clusterDesc := func() []byte { return []byte(config.ExampleYAML) }
+
+	ln, e := net.Listen("tcp", ":0") // OS will allocate a not-in-use port.
+	candy.Must(e)
+
+	go run(clusterDesc, ccTemplate, ln)
+
+	// Retrieve a cloud-config file from the in-goroutine server.
+	r, e := http.Get(fmt.Sprintf("http://%s/cloud-config/00:25:90:c0:f7:80", ln.Addr()))
+	candy.Must(e)
+
+	cc, e := ioutil.ReadAll(r.Body)
+	candy.Must(e)
+	candy.Must(r.Body.Close())
+
+	// Compare only a small fraction -- the etcd2 initial cluster -- for testing.
+	yml := make(map[interface{}]interface{})
+	candy.Must(yaml.Unmarshal(cc, yml))
+	initialEtcdCluster := yml["coreos"].(map[interface{}]interface{})["etcd2"].(map[interface{}]interface{})["initial-cluster"]
+
+	c := &config.Cluster{}
+	candy.Must(yaml.Unmarshal([]byte(config.ExampleYAML), c))
+
+	assert.Equal(t, c.InitialEtcdCluster(), initialEtcdCluster)
+}


### PR DESCRIPTION
Fixes https://github.com/k8sp/auto-install/issues/77

为了unit test一个HTTP server，我把server的代码大幅度修改了，这样方便在一个goroutine里启动。

另外，对cloud-config-server的访问方式（URL）也修改成了？
```
http://<addr:port>/cloud-config/aa:bb:cc:dd:ee:ff
```
而不是以前的
```
http://<addr:port>/cloud-config/aa-bb-cc-dd-ee-ff.yml
```