### PR TITLE
Temporary hacky solution to vagrant cannot ssh to CentOS guests

### DIFF
--- a/bootstrapper/vmtest/run
+++ b/bootstrapper/vmtest/run
@@ -14,6 +14,15 @@ function TestInVM() {
 	cd vm
 	vagrant init $VMBOX
 	sed -i.bak 's/# config.vm.provider "virtualbox" do |vb|/config.vm.provider "virtualbox" do |vb| vb.memory = "1024" end/g' Vagrantfile
+
+	# The following line is very hacky.  It means that whenever we
+	# ssh or scp to the guest machine, we need to input password
+	# "vagrant".  We do this only because vagrant 1.8.5 has a bug
+	# which prevents passwordless login when the guest runs
+	# CentOS.  Once vagrant 1.8.6 releases, we should upgrade and
+	# remove this line.
+	sed -i.bak 's/# config.vm.box_check_update = false/config.ssh.username, config.ssh.password, config.ssh.insert_key = "vagrant", "vagrant", true/' Vagrantfile
+	
 	vagrant up
 	vagrant scp ../$PKG.test /home/vagrant/
 	vagrant ssh -c "sudo /home/vagrant/$PKG.test -test.invm"


### PR DESCRIPTION
Fixes https://github.com/k8sp/auto-install/issues/92

这是一个临时性的应对。在vagrant发布1.8.6之后就不需要了。所以我在修改的源码里做了一个很长的注释说明。

目前在跑vmtest/run的时候，在使用CentOS guest的时候，会要求大家手工三次输入口令 "vagrant"。

我尝试了，用来测试 bootstrapper/dhcp 和 bootstrapper/nginx 都通过了。