### PR TITLE
No more hacky tricks in vmtest/run

### DIFF
--- a/bootstrapper/vmtest/run
+++ b/bootstrapper/vmtest/run
@@ -30,7 +30,6 @@ fi
 
 PKG=$(basename $(go list .))
 
-# TestInVM $PKG "ubuntu/trusty64"
 TestInVM $PKG "centos/7"
 
 rm -rf vm

--- a/bootstrapper/vmtest/run
+++ b/bootstrapper/vmtest/run
@@ -14,15 +14,6 @@ function TestInVM() {
 	cd vm
 	vagrant init $VMBOX
 	sed -i.bak 's/# config.vm.provider "virtualbox" do |vb|/config.vm.provider "virtualbox" do |vb| vb.memory = "1024" end/g' Vagrantfile
-
-	# The following line is very hacky.  It means that whenever we
-	# ssh or scp to the guest machine, we need to input password
-	# "vagrant".  We do this only because vagrant 1.8.5 has a bug
-	# which prevents passwordless login when the guest runs
-	# CentOS.  Once vagrant 1.8.6 releases, we should upgrade and
-	# remove this line.
-	sed -i.bak 's/# config.vm.box_check_update = false/config.ssh.username, config.ssh.password, config.ssh.insert_key = "vagrant", "vagrant", true/' Vagrantfile
-	
 	vagrant up
 	vagrant scp ../$PKG.test /home/vagrant/
 	vagrant ssh -c "sudo /home/vagrant/$PKG.test -test.invm"
@@ -39,7 +30,7 @@ fi
 
 PKG=$(basename $(go list .))
 
-TestInVM $PKG "ubuntu/trusty64"
+# TestInVM $PKG "ubuntu/trusty64"
 TestInVM $PKG "centos/7"
 
 rm -rf vm


### PR DESCRIPTION
Fixes https://github.com/k8sp/auto-install/issues/92

The problem reported in above issue is due to a bug in Vagrant 1.8.5.  I used to think that we cannot downgrade Vagrant from 1.8.5 to 1.8.4 to escape from this bug, but I was wrong -- the uninstallation of Vagrant on Mac OS X is described [here](http://stackoverflow.com/questions/34027853/uninstall-vagrant-on-mac) as:
```
rm -rf /opt/vagrant
rm -f /usr/bin/vagrant
```
Once we do that, we can download the right version of Vagrant https://releases.hashicorp.com/vagrant/1.8.4/vagrant_1.8.4.dmg and install it.

So this PR just revert the previous change https://github.com/k8sp/auto-install/pull/96