### PR TITLE
Try build VM cluster using Vagrant

### DIFF
--- a/docker/vm-cluster/Vagrantfile
+++ b/docker/vm-cluster/Vagrantfile
@@ -2,18 +2,19 @@
 #  1. Private network: https://github.com/k8sp/auto-install/issues/102#issuecomment-238005425
 #  2. Install Docker: https://docs.docker.com/engine/installation/linux/ubuntulinux/
 Vagrant.configure("2") do |config|
-  
-  config.vm.box = "ubuntu/trusty64"
 
-  config.vm.synced_folder "~/work", "/work"
+  config.vm.define "bootstrapper" do |bs|
+    bs.vm.box = "ubuntu/trusty64"
 
-  config.vm.provider "virtualbox" do |vb|
+    bs.vm.synced_folder "~/work", "/work"
+
+    bs.vm.provider "virtualbox" do |vb|
       vb.gui = false
       vb.memory = "2048"
     end
 
-  # Install Docker on both VMs.
-  config.vm.provision "shell", inline: <<-SHELL
+    # Install Docker on both VMs.
+    bs.vm.provision "shell", inline: <<-SHELL
 apt-get update
 apt-get install -y apt-transport-https ca-certificates
 apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
@@ -29,11 +30,17 @@ usermod -aG docker vagrant
 echo '192.168.50.4 bootstrapper' >> /etc/hosts
   SHELL
 
-  config.vm.define "bootstrapper" do |bs|
-    bs.vm.network "private_network", ip: "192.168.50.4", name: "vboxnet0"
+    bs.vm.network "public_network", ip: "192.168.50.4", bridge: "en3"
+    bs.vm.hostname = "bootstrapper"
   end
 
   config.vm.define "node" do |nd|
-    nd.vm.network "private_network", ip: "192.168.50.5", name: "vboxnet0"
+    nd.vm.box = "c33s/empty"
+    nd.vm.network "public_network", type: "dhcp", bridge: "en3"
+
+    nd.vm.provider "virtualbox" do |vb|
+      vb.gui = true
+      vb.memory = "2048"
+    end
   end
 end


### PR DESCRIPTION
我按照 @pineking 在[这里](https://github.com/k8sp/auto-install/issues/102#issuecomment-238069469) 记录的经验，写了本PR里的[Vagrantfile](https://github.com/k8sp/auto-install/blob/afd7311f15f27248cbdaccb84c5e334233877810/docker/vm-cluster/Vagrantfile)。启动bootstrapper VM没问题，并且可以看到NAT网卡(eth0)和bridged网卡(eth1)的IP地址也符合期待。

```
host $ vagrant ssh bootstrapper
bootstrapper $ ifconfig
eth0      Link encap:Ethernet  HWaddr 08:00:27:5c:d2:2f  
          inet addr:10.0.2.15  Bcast:10.0.2.255  Mask:255.255.255.0
          inet6 addr: fe80::a00:27ff:fe5c:d22f/64 Scope:Link
          UP BROADCAST RUNNING MULTICAST  MTU:1500  Metric:1
          RX packets:578 errors:0 dropped:0 overruns:0 frame:0
          TX packets:414 errors:0 dropped:0 overruns:0 carrier:0
          collisions:0 txqueuelen:1000 
          RX bytes:60178 (60.1 KB)  TX bytes:52413 (52.4 KB)

eth1      Link encap:Ethernet  HWaddr 08:00:27:9d:9c:bc  
          inet addr:192.168.50.4  Bcast:192.168.50.255  Mask:255.255.255.0
          inet6 addr: fe80::a00:27ff:fe9d:9cbc/64 Scope:Link
          UP BROADCAST RUNNING MULTICAST  MTU:1500  Metric:1
          RX packets:0 errors:0 dropped:0 overruns:0 frame:0
          TX packets:18 errors:0 dropped:0 overruns:0 carrier:0
          collisions:0 txqueuelen:1000 
          RX bytes:0 (0.0 B)  TX bytes:1656 (1.6 KB)
```
但是随后`vagrant up node`的时候，DHCP失败了。VM截屏如下：

<img width="804" alt="screen shot 2016-08-25 at 9 19 03 pm" src="https://cloud.githubusercontent.com/assets/1548775/17994087/b0727686-6b0a-11e6-86bc-eb4b3a2b8b90.png">

截屏里出现 `CLIENT IP: 10.0.2.15`字样，看上去是eth0网卡（NAT）在申请DHCP？